### PR TITLE
Bugfix: Exception while measuring distance between falls in different Worlds

### DIFF
--- a/src/main/java/io/github/hugo1307/fallgates/commands/FallConnectCommand.java
+++ b/src/main/java/io/github/hugo1307/fallgates/commands/FallConnectCommand.java
@@ -15,7 +15,6 @@ import org.bukkit.command.CommandSender;
 import java.util.List;
 import java.util.stream.Collectors;
 
-
 @AutoValidation
 @Command(alias = "connect", description = "Connect a fall to another one.", permission = "fallgates.command.connect")
 @Arguments({

--- a/src/main/java/io/github/hugo1307/fallgates/commands/HelpCommand.java
+++ b/src/main/java/io/github/hugo1307/fallgates/commands/HelpCommand.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @AutoValidation
-@Command(alias = "help", description = "Provides a help page with all commands.", permission = "fallgates.command.help", isPlayerOnly = true)
+@Command(alias = "help", description = "Provides a help page with all commands.", permission = "fallgates.command.help")
 @Dependencies(dependencies = {ServiceAccessor.class})
 public class HelpCommand extends BukkitDevCommand {
 

--- a/src/main/java/io/github/hugo1307/fallgates/services/FallService.java
+++ b/src/main/java/io/github/hugo1307/fallgates/services/FallService.java
@@ -69,6 +69,7 @@ public final class FallService implements Service {
      */
     public Optional<Fall> getClosestFall(Location location) {
         return fallsCache.getAll().stream()
+                .filter(fall -> fall.getPosition().toBukkitLocation().getWorld() == location.getWorld())
                 .min(Comparator.comparingDouble(fall -> fall.getPosition().toBukkitLocation().distance(location)));
     }
 


### PR DESCRIPTION
This PR fixes an exception that would be thrown when measuring the distance between falls in different worlds. This exception would interrupt the execution, and prevent falls from opening.