### PR TITLE
Feature: Configurable settings for Falls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.hugo1307</groupId>
     <artifactId>fallgates</artifactId>
-    <version>0.0.2-beta</version>
+    <version>0.0.3-beta</version>
     <packaging>jar</packaging>
 
     <name>fallgates</name>

--- a/src/main/java/io/github/hugo1307/fallgates/config/entities/FallsConfigEntry.java
+++ b/src/main/java/io/github/hugo1307/fallgates/config/entities/FallsConfigEntry.java
@@ -6,7 +6,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum FallsConfigEntry implements ConfigEntry {
-    OPEN_TIME("openTime"),
+    CLOSE_DELAY("closeDelay"),
     FALL_HEIGHT("fallHeight"),
     VERTICAL_FORCE("verticalForce"),
     HORIZONTAL_FORCE("horizontalForce");

--- a/src/main/java/io/github/hugo1307/fallgates/config/entities/FallsConfigEntry.java
+++ b/src/main/java/io/github/hugo1307/fallgates/config/entities/FallsConfigEntry.java
@@ -1,0 +1,20 @@
+package io.github.hugo1307.fallgates.config.entities;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum FallsConfigEntry implements ConfigEntry {
+    OPEN_TIME("openTime"),
+    FALL_HEIGHT("fallHeight"),
+    VERTICAL_FORCE("verticalForce"),
+    HORIZONTAL_FORCE("horizontalForce");
+
+    private final String key;
+
+    @Override
+    public String getConfigPrefix() {
+        return "falls";
+    }
+}

--- a/src/main/java/io/github/hugo1307/fallgates/listeners/FallEnterListener.java
+++ b/src/main/java/io/github/hugo1307/fallgates/listeners/FallEnterListener.java
@@ -2,6 +2,8 @@ package io.github.hugo1307.fallgates.listeners;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import io.github.hugo1307.fallgates.config.ConfigHandler;
+import io.github.hugo1307.fallgates.config.entities.FallsConfigEntry;
 import io.github.hugo1307.fallgates.services.FallService;
 import io.github.hugo1307.fallgates.services.TeleportService;
 import org.bukkit.entity.Player;
@@ -14,11 +16,13 @@ public class FallEnterListener implements Listener {
 
     private final FallService fallService;
     private final TeleportService teleportService;
+    private final ConfigHandler configHandler;
 
     @Inject
-    public FallEnterListener(FallService fallService, TeleportService teleportService) {
+    public FallEnterListener(FallService fallService, TeleportService teleportService, ConfigHandler configHandler) {
         this.fallService = fallService;
         this.teleportService = teleportService;
+        this.configHandler = configHandler;
     }
 
     @EventHandler
@@ -29,8 +33,9 @@ public class FallEnterListener implements Listener {
         }
 
         Player player = event.getPlayer();
+        int fallHeight = configHandler.getValue(FallsConfigEntry.FALL_HEIGHT, Integer.class);
         fallService.getOpenFalls().forEach(openFall -> {
-            if (openFall.isInside(event.getTo()) && openFall.isConnected() && openFall.getPosition().getY() - event.getTo().getY() >= 8) {
+            if (openFall.isInside(event.getTo()) && openFall.isConnected() && openFall.getPosition().getY() - event.getTo().getY() >= fallHeight) {
                 fallService.getFallById(openFall.getTargetFallId()).ifPresent(targetFall -> teleportService.teleportToFall(player, targetFall));
             }
         });

--- a/src/main/java/io/github/hugo1307/fallgates/listeners/FallInteractListener.java
+++ b/src/main/java/io/github/hugo1307/fallgates/listeners/FallInteractListener.java
@@ -43,8 +43,10 @@ public class FallInteractListener implements Listener {
         }
 
         Fall closestFall = closestFallOptional.get();
+        int closestFallMaxSize = Math.max(closestFall.getXSize(), closestFall.getZSize());
         // If the pressure plate is too far from the closest fall AND the pressure plate is not inside the closest fall, ignore
-        if (!closestFall.isInside(pressurePlateLocation) && closestFall.getPosition().toBukkitLocation().distance(pressurePlateLocation) > 5) {
+        if (!closestFall.isInside(pressurePlateLocation)
+                && closestFall.getPosition().toBukkitLocation().distance(pressurePlateLocation) > closestFallMaxSize * 2) {
             return;
         }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -6,7 +6,7 @@ database:
 
 # General Falls configuration
 falls:
-  openTime: 5                     # Time (in seconds) to keep the fall open before closing
+  closeDelay: 5                   # Time (in seconds) to keep the fall open before closing
   fallHeight: 8                   # Height to trigger the teleportation when falling through a gate
   verticalForce: 0.2              # Vertical push force when falling through a gate
   horizontalForce: 0.2            # Horizontal push force when falling through a gate

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -3,3 +3,10 @@ database:
   name: "fall_gates"              # The name of the database
   user: "root"                    # The user of the database
   password: "admin"               # The password of the database user
+
+# General Falls configuration
+falls:
+  openTime: 5                     # Time (in seconds) to keep the fall open before closing
+  fallHeight: 8                   # Height to trigger the teleportation when falling through a gate
+  verticalForce: 0.2              # Vertical push force when falling through a gate
+  horizontalForce: 0.2            # Horizontal push force when falling through a gate


### PR DESCRIPTION
This PR adds configurable settings that can be adjusted in the `config.yml` and will apply to all falls in the server. These settings allow server admins to configure:
* The time to wait before closing an open fall;
* The height of the fall (i.e., the number of blocks to allow the player to fall before teleporting him to the connected fall);
* The vertical and horizontal push forces applied to the players when they leave the target fall; 